### PR TITLE
Fix double quotes and "read" suggested by shellcheck

### DIFF
--- a/gnupg-hook
+++ b/gnupg-hook
@@ -9,13 +9,13 @@ run_hook() {
     mktmp() {
         i=1
         while [ -e /tmp/$i ]; do
-            i=$(($i + 1))
+            i=$((i + 1))
         done
         echo -n "/tmp/$i"
     }
 
     get_file() {
-        IFS=: read -r ckdev ckarg1 ckarg2 ckarg3 <<EOF
+        IFS=: read ckdev ckarg1 ckarg2 ckarg3 <<EOF
 $1
 EOF
         if [ "$ckdev" = "rootfs" ];then
@@ -49,7 +49,7 @@ EOF
 
     if [ -n "$gpg_import" ]; then
         while [ -n "$gpg_import" ]; do
-            IFS=\; read -r file gpg_import <<EOF
+            IFS=\; read file gpg_import <<EOF
 $gpg_import
 EOF
             gpg --homedir /tmp/gpg --import "$(get_file "$file")"
@@ -62,7 +62,7 @@ EOF
             IFS=\; read file gpg_decrypt <<EOF
 $gpg_decrypt
 EOF
-            IFS=: read -r in_file out_file <<EOF
+            IFS=: read in_file out_file <<EOF
 $(get_file "$file")
 EOF
             [ ! -f "${in_file}" ] && echo "Could not open ciphered file, aborting."

--- a/gnupg-hook
+++ b/gnupg-hook
@@ -15,7 +15,7 @@ run_hook() {
     }
 
     get_file() {
-        IFS=: read ckdev ckarg1 ckarg2 ckarg3 <<EOF
+        IFS=: read -r ckdev ckarg1 ckarg2 ckarg3 <<EOF
 $1
 EOF
         if [ "$ckdev" = "rootfs" ];then
@@ -23,7 +23,7 @@ EOF
             if [ -n "$ckarg2" ]; then
                 echo -n ":$ckarg2"
             fi
-        elif resolved=$(resolve_device "${ckdev}" ${rootdelay}); then
+        elif resolved=$(resolve_device "${ckdev}" "${rootdelay}"); then
             file=$(mktmp)
             case ${ckarg1} in
                 *[!0-9]*)
@@ -49,10 +49,10 @@ EOF
 
     if [ -n "$gpg_import" ]; then
         while [ -n "$gpg_import" ]; do
-            IFS=\; read file gpg_import <<EOF
+            IFS=\; read -r file gpg_import <<EOF
 $gpg_import
 EOF
-            gpg --homedir /tmp/gpg --import $(get_file "$file")
+            gpg --homedir /tmp/gpg --import "$(get_file "$file")"
         done
     fi
 
@@ -62,11 +62,11 @@ EOF
             IFS=\; read file gpg_decrypt <<EOF
 $gpg_decrypt
 EOF
-            IFS=: read in_file out_file <<EOF
+            IFS=: read -r in_file out_file <<EOF
 $(get_file "$file")
 EOF
-            [ ! -f ${in_file} ] && echo "Could not open ciphered file, aborting."
-            gpg --homedir /tmp/gpg -o $out_file --decrypt $in_file
+            [ ! -f "${in_file}" ] && echo "Could not open ciphered file, aborting."
+            gpg --homedir /tmp/gpg -o "$out_file" --decrypt "$in_file"
         done
     fi
 }


### PR DESCRIPTION
Shellcheck report before patch:
```
In gnupg-hook line 1:
#!/usr/bin/ash
^-- SC2187: Ash scripts will be checked as Dash. Add '# shellcheck shell=dash' to silence.


In gnupg-hook line 12:
            i=$(($i + 1))
                 ^-- SC2004: $/${} is unnecessary on arithmetic variables.


In gnupg-hook line 18:
        IFS=: read ckdev ckarg1 ckarg2 ckarg3 <<EOF
        ^-- SC2162: read without -r will mangle backslashes.


In gnupg-hook line 26:
        elif resolved=$(resolve_device "${ckdev}" ${rootdelay}); then
                                                  ^-- SC2154: rootdelay is referenced but not assigned.
                                                  ^-- SC2086: Double quote to prevent globbing and word splitting.


In gnupg-hook line 52:
            IFS=\; read file gpg_import <<EOF
            ^-- SC2162: read without -r will mangle backslashes.


In gnupg-hook line 55:
            gpg --homedir /tmp/gpg --import $(get_file "$file")
                                            ^-- SC2046: Quote this to prevent word splitting.


In gnupg-hook line 60:
        gpg --homedir /tmp/gpg --card-status &> /dev/null
                                             ^-- SC2169: In dash, &> is not supported.


In gnupg-hook line 62:
            IFS=\; read file gpg_decrypt <<EOF
            ^-- SC2162: read without -r will mangle backslashes.


In gnupg-hook line 65:
            IFS=: read in_file out_file <<EOF
            ^-- SC2162: read without -r will mangle backslashes.


In gnupg-hook line 68:
            [ ! -f ${in_file} ] && echo "Could not open ciphered file, aborting."
                   ^-- SC2086: Double quote to prevent globbing and word splitting.


In gnupg-hook line 69:
            gpg --homedir /tmp/gpg -o $out_file --decrypt $in_file
                                      ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                          ^-- SC2086: Double quote to prevent globbing and word splitting.


In gnupg-hook line 76:
    killall -9 gpg-agent scdaemon pcscd &> /dev/null
                                        ^-- SC2169: In dash, &> is not supported.
```
Shellcheck report after patch:
```
In gnupg-hook line 1:
#!/usr/bin/ash
^-- SC2187: Ash scripts will be checked as Dash. Add '# shellcheck shell=dash' to silence.


In gnupg-hook line 12:
            i=$(($i + 1))
                 ^-- SC2004: $/${} is unnecessary on arithmetic variables.


In gnupg-hook line 26:
        elif resolved=$(resolve_device "${ckdev}" "${rootdelay}"); then
                                                   ^-- SC2154: rootdelay is referenced but not assigned.


In gnupg-hook line 60:
        gpg --homedir /tmp/gpg --card-status &> /dev/null
                                             ^-- SC2169: In dash, &> is not supported.


In gnupg-hook line 76:
    killall -9 gpg-agent scdaemon pcscd &> /dev/null
                                        ^-- SC2169: In dash, &> is not supported.
```
Please test before merging. I don't want locking out someone 🙂. I left the rest for your judgment.